### PR TITLE
OrbitCameraSystem: PhysicsWorld needs `[ReadOnly]`

### DIFF
--- a/Platformer/Assets/Scripts/Camera/OrbitCameraSystem.cs
+++ b/Platformer/Assets/Scripts/Camera/OrbitCameraSystem.cs
@@ -101,7 +101,7 @@ public partial struct OrbitCameraSystem : ISystem
     public partial struct OrbitCameraJob : IJobEntity
     {
         public TimeData TimeData;
-        public PhysicsWorld PhysicsWorld;
+        [ReadOnly] public PhysicsWorld PhysicsWorld;
 
         public ComponentLookup<LocalToWorld> LocalToWorldLookup;
         [ReadOnly] public ComponentLookup<KinematicCharacterBody> KinematicCharacterBodyLookup;


### PR DESCRIPTION
If not any other system trying to access PhysicsWorld creates error if other systems tries to read at same time.

`
InvalidOperationException: The previously scheduled job StatefulCollisionEventSystem:WriteEventsJob reads from the UNKNOWN_OBJECT_TYPE WriteEventsJob.JobData.PhysicsWorld.CollisionWorld.m_Bodies. You are trying to schedule a new job OrbitCameraSystem:OrbitCameraJob, which writes to the same UNKNOWN_OBJECT_TYPE (via OrbitCameraJob.JobData.PhysicsWorld.CollisionWorld.m_Bodies). To guarantee safety, you must include StatefulCollisionEventSystem:WriteEventsJob as a dependency of the newly scheduled job. Unity.Jobs.LowLevel.Unsafe.JobsUtility.Schedule (Unity.Jobs.LowLevel.Unsafe.JobsUtility+JobScheduleParameters& parameters) <0x441438f0 + 0x00063> in <9b0471513ec64d3c8e9cd9485ce8df42>:0 Unity.Entities.JobChunkExtensions.ScheduleInternal[T] (T& jobData, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependsOn, Unity.Jobs.LowLevel.Unsafe.ScheduleMode mode, Unity.Collections.NativeArray`1[T] chunkBaseEntityIndices) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/IJobChunk.cs:327) Unity.Entities.JobChunkExtensions.ScheduleByRef[T] (T& jobData, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependsOn) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/IJobChunk.cs:158) OrbitCameraSystem+OrbitCameraJob+InternalCompilerQueryAndHandleData.Schedule (OrbitCameraSystem+OrbitCameraJob& job, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependency) (at JobEntityGenerator/Unity.Entities.SourceGen.JobEntityGenerator.JobEntityGenerator/Temp/GeneratedCode/Platformers.Data/OrbitCameraSystem__JobEntity_155907095591.g.cs:208) OrbitCameraSystem.__ScheduleViaJobChunkExtension_0 (OrbitCameraSystem+OrbitCameraJob job, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependency, Unity.Entities.SystemState& state, System.Boolean hasUserDefinedQuery) (at <0ab3346255cd47c7a013d729d3355084>:0) OrbitCameraSystem.OnUpdate (Unity.Entities.SystemState& state) (at Assets/Scripts/Platformers/Platformers.Data/Camera/OrbitCameraSystem.cs:89) OrbitCameraSystem.__codegen__OnUpdate (System.IntPtr self, System.IntPtr state) (at <0ab3346255cd47c7a013d729d3355084>:0) Unity.Entities.SystemBaseRegistry+<>c__DisplayClass9_0.<SelectBurstFn>b__0 (System.IntPtr system, System.IntPtr state) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/SystemBaseRegistry.cs:249) UnityEngine.Debug:LogException(Exception)
Unity.Debug:LogException(Exception) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/Stubs/Unity/Debug.cs:17) Unity.Entities.<>c__DisplayClass9_0:<SelectBurstFn>b__0(IntPtr, IntPtr) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/SystemBaseRegistry.cs:253) Unity.Entities.UnmanagedUpdate_000015D9$BurstDirectCall:wrapper_native_indirect_0x5d48d25ea420(IntPtr&, Void*) Unity.Entities.UnmanagedUpdate_000015D9$BurstDirectCall:Invoke(Void*) Unity.Entities.WorldUnmanagedImpl:UnmanagedUpdate(Void*) Unity.Entities.WorldUnmanagedImpl:UpdateSystem(SystemHandle) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/WorldUnmanaged.cs:895) Unity.Entities.ComponentSystemGroup:UpdateAllSystems() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/ComponentSystemGroup.cs:709) Unity.Entities.ComponentSystemGroup:OnUpdate() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/ComponentSystemGroup.cs:679) Unity.Entities.SystemBase:Update() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/SystemBase.cs:420) Unity.Entities.DummyDelegateWrapper:TriggerUpdate() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/ScriptBehaviourUpdateOrder.cs:523) `